### PR TITLE
Add browser support excluding node modules import

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Advanced URL Connection String parser + generator.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "browser": {
+    "./dist/inspect.js": "./dist/browser/inspect.js"
+  },
   "scripts": {
     "build": "tsc -p src && tsc -p test",
     "lint": "tslint --fix ./src/**/*.ts ./test/**/*.ts",

--- a/src/browser/inspect.ts
+++ b/src/browser/inspect.ts
@@ -1,0 +1,3 @@
+export const setupCustomInspect = (obj: any) => {
+	// No custom inspect for browsers
+};

--- a/src/inspect.ts
+++ b/src/inspect.ts
@@ -1,0 +1,23 @@
+const {inspect} = require('util');
+const {EOL} = require('os');
+
+export const setupCustomInspect = (obj: any) => {
+    // istanbul ignore else
+    if (typeof module !== 'undefined') {
+        let inspecting = false;
+        Object.defineProperty(obj.prototype, inspect.custom, {
+            value() {
+                if (inspecting) {
+                    return this;
+                }
+                inspecting = true;
+                const options = {colors: process.stdout.isTTY};
+                const src = inspect(this, options);
+                const {host, hostname, port, type} = this;
+                const vp = inspect({host, hostname, port, type}, options);
+                inspecting = false;
+                return `${src}${EOL}Virtual Properties: ${vp}`;
+            }
+        });
+    }
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import {HostType, IConnectionDefaults, IEncodingOptions, IHost, IParsedHost} from './types';
 import {decode, encode, hasText, fullHostName, parseHost, validateUrl} from './static';
+import {setupCustomInspect} from './inspect';
 
 const errInvalidDefaults = `Invalid "defaults" parameter: `;
 
@@ -347,24 +348,5 @@ export class ConnectionString {
         Object.defineProperty(ConnectionString.prototype, prop, desc);
     });
 
-    // istanbul ignore else
-    if (typeof module !== 'undefined') {
-        const {inspect} = require('util');
-        const {EOL} = require('os');
-        let inspecting = false;
-        Object.defineProperty(ConnectionString.prototype, inspect.custom, {
-            value() {
-                if (inspecting) {
-                    return this;
-                }
-                inspecting = true;
-                const options = {colors: process.stdout.isTTY};
-                const src = inspect(this, options);
-                const {host, hostname, port, type} = this;
-                const vp = inspect({host, hostname, port, type}, options);
-                inspecting = false;
-                return `${src}${EOL}Virtual Properties: ${vp}`;
-            }
-        });
-    }
+    setupCustomInspect(ConnectionString);
 })();

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,6 +9,6 @@
     "noUnusedLocals": true
   },
   "include": [
-    "./*.ts"
+    "./**/*.ts"
   ]
 }


### PR DESCRIPTION
Move node dependencies to a separated module file, and keep a copy version of that without those deps for browser support. And use the browser configuration on package.json to tell client consumers to use the browser version of that file instead.

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser

It is the same approach used by axios btw https://github.com/axios/axios/blob/master/package.json#L69-L71