### PR TITLE
Replace Travis with GitHub actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [12.x, 14.x, 16.x, 18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm install
+
+      # GitHub actions do not use a TTY, which is required for util.inspect to
+      # output in color, so use script to force a TTY.
+      - run: script --return --quiet -c "npm test" /dev/null

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,6 @@ jobs:
 
       # GitHub actions do not use a TTY, which is required for util.inspect to
       # output in color, so use script to force a TTY.
-      - run: script --return --quiet -c "npm test" /dev/null
+      - run: npm test
+        # Workaround for No TTY issue
+        shell: 'script -qec "bash {0}"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-matrix:
-  include:
-    - node_js: "12"
-      script: "npm test"
-    - node_js: "14"
-      script: "npm test travis"
-    - node_js: "16"
-      script: "npm test"


### PR DESCRIPTION
PR replaces the long defunct TravisCI configuration with a GitHub actions based one, which will run for any pushes or pull requests to `master`. Please see https://github.com/MasterOdin/connection-string/actions/runs/5595293798 for an example run of the action. The only complication to this effort is that GH does not run things in a TTY, which means that `util.inspect` doesn't print in color regardless of the value for `color: true`. By using `script`, we can force a TTY to run around the test suite, to get the behavior of how Travis would run things.

I did look for a potential CLI or environment option to force this, but couldn't find anything. For reference, the spec in question for now working is:

https://github.com/vitaly-t/connection-string/blob/1a975d1c6e12cc18386116861f36fb9cfbc45e7c/test/main.spec.ts#L742-L744