### PR TITLE
Add Node 20 to tested versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Node 20 should enter LTS in October, and so would be nice to have this library tested against that version for folks who track LTS.